### PR TITLE
🔒 [security fix] Remove exposed email address from configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,6 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 title: cuspymd
-email: cuspymd@gmail.com
 description: >- # this means to ignore newlines until "baseurl:"
   To tracks an individual's memory and history
 baseurl: "" # the subpath of your site, e.g. /blog


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Removed the exposed email address `cuspymd@gmail.com` from `_config.yml`.

### ⚠️ Risk: The potential impact if left unfixed
Exposing a personal email address in a public configuration file can lead to spam, phishing attacks, and targeted social engineering against the repository owner.

### 🛡️ Solution: How the fix addresses the vulnerability
By removing the `email` key-value pair from the configuration, we ensure that the sensitive information is no longer present in the source code or site metadata. I verified that this variable was not used in any of the site's Liquid templates (`_includes` or `_layouts`), so there is no impact on the user interface.

---
*PR created automatically by Jules for task [12278743723385143401](https://jules.google.com/task/12278743723385143401) started by @cuspymd*